### PR TITLE
Update root project name so that usages in urls point to the correct location

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -15,7 +15,7 @@ buildscript {
 
 apply plugin: 'org.kordamp.gradle.kordamp-parentbuild'
 
-rootProject.name = 'testcontainers-redis-build'
+rootProject.name = 'testcontainers-redis'
 
 projects {
     directories = ['subprojects']


### PR DESCRIPTION
Fixes #15

## Changes
* Update root project name from `testcontainers-redis-build` to `testcontainers-redis` 